### PR TITLE
Allow to use centered title in AdaptiveTopAppBar with Material3 theme using MaterialTopAppBarAdaptation

### DIFF
--- a/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
+++ b/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
@@ -70,7 +70,7 @@ fun AdaptiveTopAppBar(
         material = {
             SingleRowTopAppBar(
                 title = title,
-                isCenterAligned = it.isCenteredAligned,
+                isCenterAligned = it.isCenterAligned,
                 colors = it.colors,
                 modifier = modifier,
                 navigationIcon = navigationIcon,

--- a/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
+++ b/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
@@ -19,6 +19,7 @@ package io.github.alexzhirkevich.cupertino.adaptive
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
@@ -67,23 +68,58 @@ fun AdaptiveTopAppBar(
             )
         },
         material = {
-            TopAppBar(
+            SingleRowTopAppBar(
                 title = title,
+                centeredTitle = it.centeredTitle,
+                colors = it.colors,
                 modifier = modifier,
                 navigationIcon = navigationIcon,
                 actions = actions,
                 windowInsets = windowInsets,
-                colors = it.colors
             )
         }
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SingleRowTopAppBar(
+    title: @Composable () -> Unit,
+    centeredTitle: Boolean,
+    colors: TopAppBarColors,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable (RowScope.() -> Unit) = {},
+    windowInsets: WindowInsets = CupertinoTopAppBarDefaults.windowInsets,
+) {
+    if (centeredTitle) {
+        CenterAlignedTopAppBar(
+            title = title,
+            modifier = modifier,
+            navigationIcon = navigationIcon,
+            actions = actions,
+            windowInsets = windowInsets,
+            colors = colors,
+        )
+    } else {
+        TopAppBar(
+            title = title,
+            modifier = modifier,
+            navigationIcon = navigationIcon,
+            actions = actions,
+            windowInsets = windowInsets,
+            colors = colors,
+        )
+    }
+}
+
 @Stable
 @OptIn(ExperimentalMaterial3Api::class)
 class MaterialTopAppBarAdaptation internal constructor(
-    colors : TopAppBarColors
+    colors: TopAppBarColors,
+    centeredTitle: Boolean = false,
 ) {
+    var centeredTitle: Boolean by mutableStateOf(centeredTitle)
     var colors : TopAppBarColors by mutableStateOf(colors)
 }
 

--- a/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
+++ b/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
@@ -70,7 +70,7 @@ fun AdaptiveTopAppBar(
         material = {
             SingleRowTopAppBar(
                 title = title,
-                centeredTitle = it.centeredTitle,
+                isCenterAligned = it.isCenteredAligned,
                 colors = it.colors,
                 modifier = modifier,
                 navigationIcon = navigationIcon,
@@ -85,14 +85,14 @@ fun AdaptiveTopAppBar(
 @Composable
 private fun SingleRowTopAppBar(
     title: @Composable () -> Unit,
-    centeredTitle: Boolean,
+    isCenterAligned: Boolean,
     colors: TopAppBarColors,
     modifier: Modifier = Modifier,
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable (RowScope.() -> Unit) = {},
     windowInsets: WindowInsets = CupertinoTopAppBarDefaults.windowInsets,
 ) {
-    if (centeredTitle) {
+    if (isCenterAligned) {
         CenterAlignedTopAppBar(
             title = title,
             modifier = modifier,
@@ -117,9 +117,9 @@ private fun SingleRowTopAppBar(
 @OptIn(ExperimentalMaterial3Api::class)
 class MaterialTopAppBarAdaptation internal constructor(
     colors: TopAppBarColors,
-    centeredTitle: Boolean = false,
+    isCenterAligned: Boolean = false,
 ) {
-    var centeredTitle: Boolean by mutableStateOf(centeredTitle)
+    var isCenteredAligned: Boolean by mutableStateOf(isCenterAligned)
     var colors : TopAppBarColors by mutableStateOf(colors)
 }
 

--- a/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
+++ b/cupertino-adaptive/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/adaptive/AdaptiveTopAppBar.kt
@@ -119,7 +119,7 @@ class MaterialTopAppBarAdaptation internal constructor(
     colors: TopAppBarColors,
     isCenterAligned: Boolean = false,
 ) {
-    var isCenteredAligned: Boolean by mutableStateOf(isCenterAligned)
+    var isCenterAligned: Boolean by mutableStateOf(isCenterAligned)
     var colors : TopAppBarColors by mutableStateOf(colors)
 }
 


### PR DESCRIPTION
![Screenshot_20240415_154435](https://github.com/alexzhirkevich/compose-cupertino/assets/31508068/460a320f-bbcf-412a-9e9a-7e5bb781b9c4)
