### PR TITLE
Add draggable interaction to `CupertinoSwitch`

### DIFF
--- a/cupertino/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/CupertinoSwitch.kt
+++ b/cupertino/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/CupertinoSwitch.kt
@@ -146,9 +146,9 @@ fun CupertinoSwitch(
 
     LaunchedEffect(dragThreshold) {
         snapshotFlow {
-            when (dragDistance) {
-                0f -> false
-                dragThreshold -> true
+            when  {
+                dragDistance < 0f -> false
+                dragDistance > dragThreshold -> true
                 else -> null
             }
         }.filterNotNull().collect(onCheckedChange)
@@ -182,7 +182,7 @@ fun CupertinoSwitch(
                             dragDistance = if (updatedChecked) dragThreshold else 0f
                         },
                         onHorizontalDrag = { c, v ->
-                            dragDistance = (dragDistance + v).coerceIn(0f, dragThreshold)
+                            dragDistance += v
                         }
                     )
                 }

--- a/cupertino/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/CupertinoSwitch.kt
+++ b/cupertino/src/commonMain/kotlin/io/github/alexzhirkevich/cupertino/CupertinoSwitch.kt
@@ -176,7 +176,7 @@ fun CupertinoSwitch(
             Modifier
                 .fillMaxHeight()
                 .aspectRatio(animatedAspectRatio)
-                .pointerInput(0){
+                .pointerInput(dragThreshold){
                     detectHorizontalDragGestures(
                         onDragStart = {
                             dragDistance = if (updatedChecked) dragThreshold else 0f


### PR DESCRIPTION
- Switch now can be toggled by dragging  
- Haptic now plays every time `checked` changes (instead of every `onCheckedChange` call)
- Thumb aspect ratio now animates also on mouse hovering besides pressing

Fixes #42 