### PR TITLE
Fix build issues preventing Android builds from working

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,5 @@ android.nonTransitiveRClass=true
 android.compileSdk=34
 android.targetSdk=34
 android.minSdk=21
+org.gradle.configuration-cache=true
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,14 @@ rootProject.name = "compose-cupertino"
 
 startParameter.excludedTaskNames += ":example:androidApp:build"
 startParameter.excludedTaskNames += ":example:desktopApp:build"
+startParameter.excludedTaskNames += ":example:desktopApp:compileKotlinDesktop"
 startParameter.excludedTaskNames += ":example:webApp:build"
+startParameter.excludedTaskNames += ":example:webApp:compileKotlinJs"
+startParameter.excludedTaskNames += ":example:webApp:compileKotlinWasmJs"
 startParameter.excludedTaskNames += ":example:shared:build"
+startParameter.excludedTaskNames += ":example:shared:compileKotlinDesktop"
+startParameter.excludedTaskNames += ":example:shared:compileKotlinJs"
+startParameter.excludedTaskNames += ":example:shared:compileKotlinWasmJs"
 
 include(
     ":cupertino",


### PR DESCRIPTION
My latest changes must have broken android builds, this PR optimizes the exclusion strategy to avoid building the example via `gradlew build` while still allowing the example apps to be built from Android Studio or CLI.